### PR TITLE
Delivery for CrowdSource Manager AGOL 5.3 Sprint 1

### DIFF
--- a/js/widgets/data-viewer/data-viewer.js
+++ b/js/widgets/data-viewer/data-viewer.js
@@ -558,6 +558,9 @@ define([
                         type = this._displayColumn[j].type;
                         value = this._features[i].attributes[fieldName];
                         dateFormat = this.appUtils.getDateFormat(format).dateFormat;
+                        if (fieldName === this.selectedOperationalLayer.objectIdField) {
+                            type = "esriFieldTypeOID";
+                        }
                         switch (type) {
                         case "esriFieldTypeOID":
                             dataSet.push(value);
@@ -692,7 +695,7 @@ define([
                     theadClass = this._createClassName(this._displayColumn[i].fieldName);
                     // if objectId field flag visible not true on pop up and this column is of object id fields
                     // then hide this column
-                    if ((this._displayColumn[i].type === "esriFieldTypeOID") && (!this._displayColumn[i].showObjectIdField)) {
+                    if ((this._displayColumn[i].type === "esriFieldTypeOID" || this.selectedOperationalLayer.objectIdField === this._displayColumn[i].fieldName) && (!this._displayColumn[i].showObjectIdField)) {
                         columnHeader = domConstruct.create("th", { "class": "esriCTHiddenColumn " + theadClass, "style": "min-width:300px;" });
                         domAttr.set(columnHeader, "colid", i);
                     } else {

--- a/js/widgets/details-panel/comment-form.js
+++ b/js/widgets/details-panel/comment-form.js
@@ -148,7 +148,7 @@ define([
                     // have to do Check for reported by field in case logged in user
                     layerField = layerFields[popupField.fieldName];
                     // check if layer is editable
-                    if (layerField && popupField.isEditable && $.inArray(layerField.type, excludeDataTypes) === -1) {
+                    if ((layerField && popupField.isEditable && $.inArray(layerField.type, excludeDataTypes) === -1) || (layerField && this.commentTable.typeIdField === layerField.name)) {
                         layerField.alias = popupField.label;
                         layerField.editable = popupField.isEditable;
                         layerField.tooltip = popupField.tooltip;
@@ -478,6 +478,9 @@ define([
             userFormNode = this.commentForm;
             //code to put asterisk mark for mandatory fields and also to give it a mandatory class.
             formContent = domConstruct.create("div", {}, userFormNode);
+            if (currentField.typeField && (!currentField.editable)) {
+                domClass.add(formContent, "esriCTHidden");
+            }
             // If dependent field has Reference Node
             if (referenceNode) {
                 domConstruct.place(formContent, referenceNode, "after");

--- a/js/widgets/details-panel/popup-form.js
+++ b/js/widgets/details-panel/popup-form.js
@@ -147,6 +147,7 @@ define([
             this._sortedFields = [];
             // DataTypes to be excluded from Geo Form
             excludeDataTypes = ["esriFieldTypeOID", "esriFieldTypeBlob", "esriFieldTypeRaster", "esriFieldTypeGUID", "esriFieldTypeGlobalID", "esriFieldTypeXML"];
+
             if (this.itemInfos && this.itemInfos.itemData) {
                 //To maintain the order of the fields form pop up configuration first get all fields info in layerFields array
                 //then iterate through popupInfo and create fields to be shown in geo form.
@@ -163,7 +164,7 @@ define([
                     // have to do Check for reported by field in case logged in user
                     layerField = layerFields[popupField.fieldName];
                     // check if layer is editable
-                    if (layerField && popupField.isEditable && $.inArray(layerField.type, excludeDataTypes) === -1) {
+                    if ((layerField && popupField.isEditable && ($.inArray(layerField.type, excludeDataTypes) === -1) && (this.selectedLayer.objectIdField !== layerField.name)) || (layerField && this.selectedLayer.typeIdField === layerField.name)) {
                         layerField.alias = popupField.label;
                         layerField.editable = popupField.isEditable;
                         layerField.tooltip = popupField.tooltip;
@@ -398,6 +399,9 @@ define([
             userFormNode = this.popupForm;
             //code to put asterisk mark for mandatory fields and also to give it a mandatory class.
             formContent = domConstruct.create("div", {}, userFormNode);
+            if (currentField.typeField && (!currentField.editable)) {
+                domClass.add(formContent, "esriCTHidden");
+            }
             // If dependent field has Reference Node
             if (referenceNode) {
                 domConstruct.place(formContent, referenceNode, "after");

--- a/js/widgets/search/search.js
+++ b/js/widgets/search/search.js
@@ -224,7 +224,7 @@ define([
         _getNewDefinitionExpression: function () {
             var layerObject, i, definitionExpression = null, searchDefinitionExpression;
             // After user search for a particular value that definition expression, including the default one if merged together and returned
-            if (this.itemInfo.itemData.applicationProperties.viewing.search && this.itemInfo.itemData.applicationProperties.viewing.search.enabled) {
+            if (this.itemInfo.itemData.applicationProperties && this.itemInfo.itemData.applicationProperties.viewing.search && this.itemInfo.itemData.applicationProperties.viewing.search.enabled) {
                 for (i = 0; i < this.itemInfo.itemData.applicationProperties.viewing.search.layers.length; i++) {
                     if (this.selectedOperationalLayerID === this.itemInfo.itemData.applicationProperties.viewing.search.layers[i].id) {
                         layerObject = this.itemInfo.itemData.applicationProperties.viewing.search.layers[i];


### PR DESCRIPTION
This build addresses the following GitHub issues:
#226 BUG-000105122 The Crowdsource Manager does not zoom to or select
data in the map preview that does not have an ObjectID field.
#221 BUG-000101689 Attribute fields that are subtype dependent with a
domain applied do not display when editing in the Crowdsource Manager
web app unless all fields in the feature layer are selected to be
editable.